### PR TITLE
Add per-message RSSI computation to demod_8000

### DIFF
--- a/demod_8000.c
+++ b/demod_8000.c
@@ -236,7 +236,45 @@ void demodulate8000(struct mag_buf *mag)
 
                     message_result = decodeModesMessage(&mm, best_msg);
 
-                    if ((mm.addr) && (message_result >= 0)) useModesMessage(&mm);
+                    if (message_result < 0) {
+                        if (message_result == -1)
+                            Modes.stats_current.demod_rejected_unknown_icao++;
+                        else
+                            Modes.stats_current.demod_rejected_bad++;
+                    } else {
+                        Modes.stats_current.demod_accepted[mm.correctedbits]++;
+                    }
+
+                    if ((mm.addr) && (message_result >= 0)) {
+                        // Per-message signal power measurement (RSSI)
+                        // Mirrors demod_2400.c lines 431-449.
+                        // At 8 Msps, 1 bit = D8M_NUM_PHASES (8) samples.
+                        int msg_bits = (mm.msgtype & 0x10) ? MODES_LONG_MSG_BITS : MODES_SHORT_MSG_BITS;
+                        int signal_len = msg_bits * D8M_NUM_PHASES;
+                        // position points PAST the message data (decode loop advances dptr by
+                        // (msg_bytes+D8M_SEARCH_BYTES)*8*D8M_NUM_PHASES, so position = dptr-64+i*8
+                        // ends ~64 samples beyond data end). Walk BACKWARDS by signal_len.
+                        int sample_start = (position - D8M_LOOK_AHEAD) - signal_len;
+                        if (sample_start < 0) sample_start = 0;
+
+                        uint64_t scaled_signal_power = 0;
+                        for (int k = 0; k < signal_len && (sample_start + k) < (int)mag->length; ++k) {
+                            uint32_t mag_sample = m[sample_start + k];
+                            scaled_signal_power += (uint64_t)mag_sample * (uint64_t)mag_sample;
+                        }
+
+                        double signal_power = scaled_signal_power / 65535.0 / 65535.0;
+                        mm.signalLevel = signal_power / (signal_len > 0 ? signal_len : 1);
+                        Modes.stats_current.signal_power_sum += signal_power;
+                        Modes.stats_current.signal_power_count += signal_len;
+
+                        if (mm.signalLevel > Modes.stats_current.peak_signal_power)
+                            Modes.stats_current.peak_signal_power = mm.signalLevel;
+                        if (mm.signalLevel > 0.50119)
+                            Modes.stats_current.strong_signal_count++; // signal power above -3dBFS
+
+                        useModesMessage(&mm);
+                    }
                 }
 
                 // now backtrack by 56 bits, as we may have missed peaks in this region


### PR DESCRIPTION
## Summary

The 8 MHz demodulator (`demod_8000.c`) was missing the per-message signal power measurement that `demod_2400.c` performs. As a result `mm.signalLevel` was never populated when running with `--oversample` on SDRplay devices, causing downstream consumers (Beast output signal byte in `net_io.c:406`, JSON `"rssi"` field in `net_io.c:996`, `track.c` `signalLevel` ring buffer) to receive a default sentinel value that ADS-B viewers like tar1090 treat as "no data" and hide.

## What this patch does

- Ports the signal-power measurement block from `demod_2400.c` (lines 431-449) to `demod_8000.c`, after a successful decode
- Adapts the sample math for 8 Msps: `signal_len = msg_bits * D8M_NUM_PHASES` (where `D8M_NUM_PHASES = 8` samples per bit at 8 Msps)
- Reads `mag->data` starting at `position - D8M_LOOK_AHEAD` (the message location already established by the demodulator's peak-search step)
- Also adds the `demod_accepted` / `demod_rejected_unknown_icao` / `demod_rejected_bad` stats counters that `demod_2400.c` populates but `demod_8000.c` was missing — `/run/dump1090/stats.json` now reports accurate decoder statistics under `--oversample` mode

## What this patch does NOT change

- No changes to `net_io.c`, `dump1090.c`, `mode_s.c`, the `modesMessage` struct, or any header file
- The existing infrastructure for serializing `signalLevel` to Beast (signal byte at offset 4 of each frame), JSON (`"rssi"` field), and the `track.c` ring buffer was already in place — `demod_8000` simply was not populating it

## Testing

Tested on **SDRplay RSPdx** with a Jetvision Active Diapason 1090 MHz antenna. Built with `SDRPLAY=1 make` on Debian 13 trixie, gcc 14.2.0, SDRplay API v3.15.

### Before (mainline)

All aircraft in `aircraft.json` reported `"rssi": -49.5` regardless of actual signal strength. This is the value computed from `signalLevel = 0` through `10*log10(0 + 1e-5)/8 ≈ -49.5`.

Downstream readers like tar1090 hide RSSI when ≤ -49.4 (the "no data" threshold in `planeObject.js`), so the column was always blank.

### After (with this patch)

Per-aircraft RSSI varies realistically:
- Strong nearby aircraft: −20 to −30 dBFS
- Mid-range traffic: −30 to −40 dBFS
- Distant edge-of-range aircraft: −40 to −47 dBFS

Tar1090 RSSI column now displays values; range outline / coverage tracking work as expected.

### No regressions observed

- ~1779 position decodes/min sustained over 10+ min on production
- All feeders (FlightAware, FR24, ADSBExchange, adsb.lol) reconnected without config changes
- MLAT peer counts and sync timing unchanged
- CPU usage of dump1090 process unchanged

## Author note

Patch authored as a community contribution after diagnosing why the SDRplay fork's RSSI was always showing as "no data" while the upstream readsb / dump1090-fa forks' RSSI worked correctly. The root cause was specific to the 8 MHz demodulator path; the 2.0/2.4 Msps paths were already correct.